### PR TITLE
The server may or may not populate the Record field

### DIFF
--- a/certbot_dns_google_domains/dns_google_domains.py
+++ b/certbot_dns_google_domains/dns_google_domains.py
@@ -52,7 +52,7 @@ class RotateChallengesRequest(DataClassJsonMixin):
 class AcmeChallengeSet(DataClassJsonMixin):
     dataclass_json_config = config(letter_case=LetterCase.CAMEL)[
         "dataclasses_json"]
-    record: List[AcmeTxtRecord]
+    record: Optional[List[AcmeTxtRecord]]
 
 
 class GDSApi:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "certbot-dns-google-domains"
-version = "0.1.8"
+version = "0.1.9"
 description = "Certbot DNS authenticator for Google Domains"
 authors = ["Amir Omidi <amir@aaomidi.com>"]
 license = "Apache 2.0"


### PR DESCRIPTION
Google APIs apparently don't send empty arrays as a value.

There were two solutions here:
- Either make this field optional in the code (what this PR is doing)
- Sending ?$outputDefaults as part of the request.

I don't really see a pro/con for either method. Let's go with this one.

Fixes #25 